### PR TITLE
Fix Windows builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     sha256: e362e1fbf6b101ad71aa5314f21d00a4353b90efbe5cdedc5fcfb0f3b68cd791  # [win and cuda_major == "12"]
   # Include cudart license because it is statically linked.
   - url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/LICENSE.txt
-    fn: cudart_LICENSE
+    fn: cudart_LICENSE.txt
     sha256: 5db25d4fd138013b563f9a3d1d87f7de7df1dac014fd4cccdfbb3435a5cff761
 
 build:
@@ -87,7 +87,7 @@ about:
     LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
   license_file:
     - LICENSE
-    - cudart_LICENSE
+    - cudart_LICENSE.txt
   license_url: https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
   summary: "High Speed Data Compression Using NVIDIA GPUs"
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     sha256: 5db25d4fd138013b563f9a3d1d87f7de7df1dac014fd4cccdfbb3435a5cff761
 
 build:
-  number: 0
+  number: 1
   # TODO: Enable aarch64 builds
   # TODO: Enable Windows with CUDA 12 when it is supported
   skip: True  # [win32 or osx or aarch64 or ppc64le or cuda_compiler_version not in ("11.2", "12.0") or (win and cuda_major == "12")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,10 +29,11 @@ build:
   # TODO: Enable Windows with CUDA 12 when it is supported
   skip: True  # [win32 or osx or aarch64 or ppc64le or cuda_compiler_version not in ("11.2", "12.0") or (win and cuda_major == "12")]
   script:
-    - mkdir -pv $PREFIX/include              # [linux]
-    - mv -v include/* $PREFIX/include        # [linux]
-    - mkdir -pv $PREFIX/lib                  # [linux]
-    - mv -v lib/* $PREFIX/lib/               # [linux]
+    - mv -v $SRC_DIR/LICENSE $SRC_DIR/LICENSE.txt  # [linux]
+    - mkdir -pv $PREFIX/include                    # [linux]
+    - mv -v include/* $PREFIX/include              # [linux]
+    - mkdir -pv $PREFIX/lib                        # [linux]
+    - mv -v lib/* $PREFIX/lib/                     # [linux]
     - mkdir %LIBRARY_INC%                                   # [win]
     - copy %SRC_DIR%\\include\\* %LIBRARY_INC%\\            # [win]
     - mkdir %LIBRARY_LIB%                                   # [win]
@@ -86,7 +87,7 @@ about:
   license:
     LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
   license_file:
-    - LICENSE
+    - LICENSE.txt
     - cudart_LICENSE.txt
   license_url: https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
   summary: "High Speed Data Compression Using NVIDIA GPUs"


### PR DESCRIPTION
Windows expects an extension on the license files (both the `cudart` one that is downloaded and the one in the package). Go ahead and add these in both cases. Align Linux to match the same format.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
