### PR TITLE
nvCOMP: Updating python wheels to version 5.2.0.13

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,9 @@ jobs:
       win_64_cuda_compiler_version12.9python3.13.____cp313:
         CONFIG: win_64_cuda_compiler_version12.9python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version12.9python3.14.____cp314:
+        CONFIG: win_64_cuda_compiler_version12.9python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version13.0python3.10.____cpython:
         CONFIG: win_64_cuda_compiler_version13.0python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -31,6 +34,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version13.0python3.13.____cp313:
         CONFIG: win_64_cuda_compiler_version13.0python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version13.0python3.14.____cp314:
+        CONFIG: win_64_cuda_compiler_version13.0python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314.yaml
@@ -1,0 +1,37 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314.yaml
@@ -1,0 +1,37 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,41 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+        # Manually migrated (e.g. were blocked on missing dev dependencies)
+        - pyarrow
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- vs2022
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- vs2022
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- win-64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -42,6 +42,11 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -58,6 +63,11 @@ jobs:
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -82,6 +92,11 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -98,6 +113,11 @@ jobs:
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -95,6 +102,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -126,6 +140,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -151,6 +172,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -182,6 +210,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_cuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -207,6 +242,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+build_platform:
+  linux_aarch64: linux_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
@@ -6,5 +8,3 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-build_platform:
-  linux_aarch64: linux_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.0.10" %}
+{% set version = "5.2.0.13" %}
 
 package:
   name: nvcomp
@@ -7,19 +7,19 @@ package:
 {% set arm_variant_type = arm_variant_type | default("None") %}
 {% set cuda_compiler_version = cuda_compiler_version | default("None") %}
 source:
-  - url: "https://files.pythonhosted.org/packages/36/e4/9947cf1881e1e0451f1aaa10ca9db688b229736a1e9946432e5ed722372d/nvidia_nvcomp_cu12-{{ version }}-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("12")]
-    sha256: "40becb2ec4c14d5a183bb6c4154fa4283232e39a202ab3822b59b622b2ec99a3"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("12")]E
-  - url: "https://files.pythonhosted.org/packages/69/5d/a3ea3ae84389e3330c383b5c1d533d36ff10be87a81c1553154e7a408bb0/nvidia_nvcomp_cu12-{{ version }}-py3-none-manylinux_2_26_aarch64.whl"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("12") and arm_variant_type == "sbsa"]
-    sha256: "fb44c245f8ce7dbf4d6cb915b1b955e7f2369fba723ca294da3631a712fdf401"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("12") and arm_variant_type == "sbsa"]
-  - url: "https://files.pythonhosted.org/packages/03/b6/5c552a181066e7a2e1825eff8580acaeb9459fd0bf172481abeb6176fc02/nvidia_nvcomp_cu12-{{ version }}-py3-none-win_amd64.whl"  # [win and x86_64 and (cuda_compiler_version or "").startswith("12")]
-    sha256: "7e2b3cdb888b710bbe0a27ba4b582105cb02ccf7999259a1066656f8533e2dab"  # [win and x86_64 and (cuda_compiler_version or "").startswith("12")]
+  - url: "https://files.pythonhosted.org/packages/e5/75/f9436615f16187d9e6d49c507fb00927d9dfab79ad3daf269a3761fb4c74/nvidia_nvcomp_cu12-{{ version }}-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("12")]
+    sha256: "c1797b45e041513af8bfc8aad2d727501f15ffbca633a419fd8a8e0ebb7b6a20"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("12")]
+  - url: "https://files.pythonhosted.org/packages/2b/a6/76464cc820f29fc02d21bc22ba369c53fe73ffe9cd62b94adadd5c6803f6/nvidia_nvcomp_cu12-{{ version }}-py3-none-manylinux_2_26_aarch64.whl"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("12") and arm_variant_type == "sbsa"]
+    sha256: "c67cd3ca1089078078c0002d58f60c5783cd1905db346bea86499918bcb7bb2e"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("12") and arm_variant_type == "sbsa"]
+  - url: "https://files.pythonhosted.org/packages/bb/2a/0d02110d94d9dbf20f15d6a8ffa783b60ed681e4962342ee9d8e31d90de2/nvidia_nvcomp_cu12-{{ version }}-py3-none-win_amd64.whl"  # [win and x86_64 and (cuda_compiler_version or "").startswith("12")]
+    sha256: "673894e405f8a3a49790a1fe9de2125fb07a200d47faf8810fdecd4c0577dabe"  # [win and x86_64 and (cuda_compiler_version or "").startswith("12")]
 
-  - url: "https://files.pythonhosted.org/packages/eb/32/b880a444cbd46c27ae6d1f15abd32ec1fc04ae72cb83136b57e237270363/nvidia_nvcomp_cu13-{{ version }}-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("13")]
-    sha256: "a4d27a116f5f2375c41ce929b17833a562bf794bd07dd56846741f030df91e1e"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("13")]
-  - url: "https://files.pythonhosted.org/packages/e8/43/2ad0433ed22f5b39ae0f9dbfdd98c4dfeaded6236dca9166249529693a18/nvidia_nvcomp_cu13-{{ version }}-py3-none-manylinux_2_26_aarch64.whl"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("13") and arm_variant_type == "sbsa"]
-    sha256: "a54b763f5f4b32020a29e78e2dccbbd7dc886c9acc4663a12e44de2554c5b271"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("13") and arm_variant_type == "sbsa"]
-  - url: "https://files.pythonhosted.org/packages/2e/b8/8b9cafff71ffeb8fcea08e7272f1eca417a55d16822ca03cec9699242b9b/nvidia_nvcomp_cu13-{{ version }}-py3-none-win_amd64.whl"  # [win and x86_64 and (cuda_compiler_version or "").startswith("13")]
-    sha256: "9853e331170e2fba4b17376c12e4db5060eddd6e1d5fff464fff394667e2f150"  # [win and x86_64 and (cuda_compiler_version or "").startswith("13")]
+  - url: "https://files.pythonhosted.org/packages/e3/90/7a16ea70a1dc17843713bfc1fd308f9bafd51cacedb54e647aed5eb043c5/nvidia_nvcomp_cu13-{{ version }}-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("13")]
+    sha256: "73634520491a57eeffa0b2bd0b86686a6e0af51f33099df7be3b5c21697d9f44"  # [linux and x86_64 and (cuda_compiler_version or "").startswith("13")]
+  - url: "https://files.pythonhosted.org/packages/99/61/bf5b63c9902b985acb65af8714b997edf506fc38a25b367d3f6ee613f06a/nvidia_nvcomp_cu13-{{ version }}-py3-none-manylinux_2_26_aarch64.whl"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("13") and arm_variant_type == "sbsa"]
+    sha256: "a2b3228ab85e327cdc1e400879387b02db45cc28842583c5d5c199a20913eb75"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("13") and arm_variant_type == "sbsa"]
+  - url: "https://files.pythonhosted.org/packages/82/92/8e9afe459692e5a2724def6f9a17769fb155f872ae3a1f93b97cd9baa4a9/nvidia_nvcomp_cu13-{{ version }}-py3-none-win_amd64.whl"  # [win and x86_64 and (cuda_compiler_version or "").startswith("13")]
+    sha256: "7b1553ed8e8c73e3792675e81b130989ebec319006bbdb499bc04a416a5d8834"  # [win and x86_64 and (cuda_compiler_version or "").startswith("13")]
 
   # Include cudart license because it is statically linked.
   - url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or ppc64le or not (cuda_compiler_version or "").startswith("1")]
   ignore_run_exports:
     - cuda-version


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This PR updates the Python wheel source to version 5.2.0.13. This fixes:
- unnecessary libnvcomp.so duplication in nvcomp-cuXX wheels
- python version support for Python 3.14

<!--
Please add any other relevant info below:
-->