### PR TITLE
Script fix for free-threading support

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -23,6 +23,9 @@ jobs:
       win_64_cuda_compiler_version12.9python3.14.____cp314:
         CONFIG: win_64_cuda_compiler_version12.9python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version12.9python3.14.____cp314t:
+        CONFIG: win_64_cuda_compiler_version12.9python3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version13.0python3.10.____cpython:
         CONFIG: win_64_cuda_compiler_version13.0python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -37,6 +40,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version13.0python3.14.____cp314:
         CONFIG: win_64_cuda_compiler_version13.0python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version13.0python3.14.____cp314t:
+        CONFIG: win_64_cuda_compiler_version13.0python3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t.yaml
@@ -1,0 +1,37 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t.yaml
@@ -1,0 +1,37 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/migrations/python314t.yaml
+++ b/.ci_support/migrations/python314t.yaml
@@ -1,0 +1,54 @@
+migrator_ts: 1755739493
+__migrator:
+    commit_message: Rebuild for python 3.14 freethreading
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314    # new entry
+            - 3.14.* *_cp314t   # new entry
+    longterm: true
+    pr_limit: 20
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    # if feedstock already has 3.13t migrator this is redundant, but harmless
+    additional_zip_keys:
+        - is_freethreading
+        - is_abi3
+    wait_for_migrators:
+        - python314
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+        pyarrow:
+            # optional test dependencies
+            - numba
+            - sparse
+        pyzmq:
+            # test dependency not used with free-threaded
+            - auditwheel
+    allowlist_file: free-threaded-314.txt
+
+python:
+- 3.14.* *_cp314t
+# additional entries to add for zip_keys
+is_freethreading:
+- true
+is_python_min:
+- false
+is_abi3:
+- false

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314t.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314t.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- vs2022
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314t.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314t.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- vs2022
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- win-64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -47,6 +47,11 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -68,6 +73,11 @@ jobs:
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -97,6 +107,11 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -118,6 +133,11 @@ jobs:
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -109,6 +116,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,6 +161,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -179,6 +200,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -217,6 +245,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_cuda_compiler_version12.9python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9python3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_cuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
@@ -249,6 +284,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version13.0python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19571&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcomp-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,13 @@ if errorlevel 1 exit /b 1
 :: Install the Python wheel
 %PYTHON% -m pip install .\nvidia_nvcomp_cu%major_version%-%PKG_VERSION%-py3-none-win_amd64.whl --no-deps
 
+:: Query whether the current Python was configured with GIL disabled
+for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(int(bool(sysconfig.get_config_var(\"Py_GIL_DISABLED\"))))"') do set "py_free_threaded=%%i"
+set "PY_VER_t=%PY_VER:.=%"
+if "!py_free_threaded!" == "1" (
+    set "PY_VER_t=!PY_VER_t!t"
+)
+
 :: Exit on error
 if errorlevel 1 exit /b 1
 
@@ -25,9 +32,13 @@ if errorlevel 1 exit /b 1
 for %%f in (%SP_DIR%\nvidia\nvcomp\nvcomp_impl.cp*-win_amd64.pyd) do (
     for /f "tokens=1 delims=-" %%i in ("%%~nf") do (
         set "temp=%%i"
+
+        :: Python version with optional suffix t (indicating free-threadedness), e.g., 314t, or 314
         set "file_py_ver=!temp:*.cp=!"
-        if not "!file_py_ver!" == "%PY_VER:.=%" (
-            echo Deleting %%f as its Python version ^(!file_py_ver!^) does not match %PY_VER%
+
+        :: Delete the file if the Python version or the free-threadedness does not match
+        if not "!file_py_ver!" == "!PY_VER_t!" (
+            echo Deleting %%f as its Python version ^(!file_py_ver!^) does not match !PY_VER_t!
             del "%%f"
         )
     )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,15 +4,20 @@ cuda_major=$(echo $cuda_compiler_version | cut -d. -f1)
 
 $PYTHON -m pip install ./nvidia_nvcomp_cu$cuda_major-$PKG_VERSION-*.whl --no-deps
 
+# Query free-threadedness
+py_free_threaded=$($PYTHON -c "import sysconfig; print(int(bool(sysconfig.get_config_var('Py_GIL_DISABLED'))))")
+PY_VER_t=$(echo $PY_VER | tr -d '.')
+[ "$py_free_threaded" -eq 1 ] && PY_VER_t="${PY_VER_t}t"
+
 rm -rvf $SP_DIR/nvidia/nvcomp/include
 rm -rvf $SP_DIR/nvidia/nvcomp/libnvcomp.so.*
 
 # Loop through files and delete those whose Python version does not match $PY_VER
 for file in $SP_DIR/nvidia/nvcomp/nvcomp_impl.cpython-*-linux-gnu.so; do
-    # Extract the Python version from the file name (312 for Python 3.12, etc.)
-    file_py_ver=$(echo "$file" | sed -n 's/.*\.cpython-\([0-9][0-9]*\)-.*-linux-gnu\.so/\1/p')
-    if [[ "$file_py_ver" != "$(echo $PY_VER | tr -d '.')" ]]; then
-        echo "Deleting $file as its Python version ($file_py_ver) does not match $PY_VER"
+    # Extract the Python version from the file name (312 for Python 3.12, 314t for Python 3.14t, etc.)
+    file_py_ver=$(echo "$file" | sed -n 's/.*\.cpython-\([0-9][0-9]*t*\)-.*-linux-gnu\.so/\1/p')
+    if [[ "$file_py_ver" != "$PY_VER_t" ]]; then
+        echo "Deleting $file as its Python version ($file_py_ver) does not match $PY_VER_t"
         rm "$file"
     fi
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or ppc64le or not (cuda_compiler_version or "").startswith("1")]
   ignore_run_exports:
     - cuda-version


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Previously the 314t builds were failing, because we incorrectly deleted `.so`-s and `.dll`-s that were meant to be used.
This MR is fixing our `build.sh` and `bld.bat` scripts to correctly recognize builds for free-threaded python. 

Example deletion logs:
```
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-311-x86_64-linux-gnu.so as its Python version (311) does not match 310
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-312-x86_64-linux-gnu.so as its Python version (312) does not match 310
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-313-x86_64-linux-gnu.so as its Python version (313) does not match 310
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-314t-x86_64-linux-gnu.so as its Python version (314t) does not match 310
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-314-x86_64-linux-gnu.so as its Python version (314) does not match 310
Deleting $PREFIX/lib/python3.10/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-39-x86_64-linux-gnu.so as its Python version (39) does not match 310
```

```
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-310-x86_64-linux-gnu.so as its Python version (310) does not match 314t
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-311-x86_64-linux-gnu.so as its Python version (311) does not match 314t
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-312-x86_64-linux-gnu.so as its Python version (312) does not match 314t
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-313-x86_64-linux-gnu.so as its Python version (313) does not match 314t
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-314-x86_64-linux-gnu.so as its Python version (314) does not match 314t
Deleting $PREFIX/lib/python3.14t/site-packages/nvidia/nvcomp/nvcomp_impl.cpython-39-x86_64-linux-gnu.so as its Python version (39) does not match 314t
```

<!--
Please add any other relevant info below:
-->
